### PR TITLE
Avoid issue when calling bind() with rvalue

### DIFF
--- a/libsqlite.hpp
+++ b/libsqlite.hpp
@@ -139,7 +139,17 @@ namespace sqlite
                     sqlite3_column_bytes(this->_s, fieldnumber));
         }
 
-        void bind(int where, std::string text)
+        void bind(int where, const std::string& text)
+        {
+            int rc = sqlite3_bind_text(this->_s, where, text.c_str(), text.length(), SQLITE_STATIC);
+            if(rc != SQLITE_OK)
+            {
+                exception e("Could not bind text.");
+                throw e;
+            }
+        }
+
+        void bind(int where, const std::string&& text)
         {
             int rc = sqlite3_bind_text(this->_s, where, text.c_str(), text.length(), SQLITE_TRANSIENT);
             if(rc != SQLITE_OK)
@@ -148,6 +158,7 @@ namespace sqlite
                 throw e;
             }
         }
+
         void bind(int where, double d)
         {
             int rc = sqlite3_bind_double(this->_s, where, d);

--- a/libsqlite.hpp
+++ b/libsqlite.hpp
@@ -141,7 +141,7 @@ namespace sqlite
 
         void bind(int where, std::string text)
         {
-            int rc = sqlite3_bind_text(this->_s, where, text.c_str(), text.length(), SQLITE_STATIC);
+            int rc = sqlite3_bind_text(this->_s, where, text.c_str(), text.length(), SQLITE_TRANSIENT);
             if(rc != SQLITE_OK)
             {
                 exception e("Could not bind text.");


### PR DESCRIPTION
At present there's an issue if you call bind more than once on a prepared query using rvalues. This is the fix.